### PR TITLE
Add shared CI workflow configuration for Java projectFeature/ci shared

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -1,0 +1,42 @@
+name: Shared CI Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        required: true
+        type: string
+      deploy:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    name: ${{ inputs.job-name }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: oracle
+          java-version: ${vars.JDK_VERSION}
+          server-id: github
+          server-username: ${{ github.actor }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build and Verify
+        run: mvn clean verify --batch-mode
+
+      - name: Deploy to Maven (if enabled)
+        if: ${{ inputs.deploy == true }}
+        run: mvn deploy -DskipTests


### PR DESCRIPTION
### CI Workflow:
* Introduced a reusable GitHub Actions workflow (`ci-shared.yml`) for building and verifying Maven projects. The workflow supports optional deployment to Maven repositories and caches Maven dependencies for efficiency. (`.github/workflows/ci-shared.yml`, [.github/workflows/ci-shared.ymlR1-R42](diffhunk://#diff-20aca357e16bcaabb2fe949dae964eca93531393ce8ff82d372a8b3ca4a409beR1-R42))