### PR TITLE
Add distribution management for GitHub Packages in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,19 @@
 			<id>github</id>
 			<name>GitHub Packages</name>
 			<url>https://maven.pkg.github.com/elara-app/validations-test</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
 		</repository>
+
+		<snapshotRepository>
+			<id>github</id>
+			<name>GitHub Packages - Snapshots</name>
+			<url>https://maven.pkg.github.com/elara-app/validations-test</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</snapshotRepository>
 	</distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,4 +51,12 @@
 		</plugins>
 	</build>
 
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Packages</name>
+			<url>https://maven.pkg.github.com/elara-app/validations-test</url>
+		</repository>
+	</distributionManagement>
+
 </project>


### PR DESCRIPTION
This pull request adds configuration for publishing artifacts to GitHub Packages in the `pom.xml` file.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R54-R61): Introduced a `<distributionManagement>` section with a repository configuration for GitHub Packages, specifying the repository ID, name, and URL.