### PR TITLE
Add CI versioning workflow and versions-maven-plugin configuration

### DIFF
--- a/.github/workflows/ci-pr-validator.yml
+++ b/.github/workflows/ci-pr-validator.yml
@@ -1,4 +1,5 @@
-name: CI Versioning by Branch
+name: CI Pull Request Validation
+
 on:
   pull_request:
     branches:
@@ -10,6 +11,8 @@ on:
 jobs:
   set-version:
     runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,7 +26,7 @@ jobs:
           BRANCH="${{ steps.branch.outputs.branch }}"
           case "$BRANCH" in
             main)
-              echo "version=$(date +'%Y.%m.%d')" >> "$GITHUB_OUTPUT"
+              echo "version=$(date +'%Y.%m.%d-PR')" >> "$GITHUB_OUTPUT"
               ;;
             develop)
               echo "version=0.0.1-SNAPSHOT" >> "$GITHUB_OUTPUT"
@@ -35,31 +38,24 @@ jobs:
               echo "version=1.0.1-${BRANCH##*/}" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "version=0.0.1-unknown" >> "$GITHUB_OUTPUT"
+              echo "version=0.0.1-unknown-PR" >> "$GITHUB_OUTPUT"
               ;;
           esac
+          echo "Calculated PR version: ${{ steps.version.outputs.version }}"
 
-      - name: Update pom.xml Version
+      - name: Update pom.xml Version (for CI testing)
         run: mvn org.codehaus.mojo:versions-maven-plugin:2.18.0:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
 
-      - name: Commit Version Bump
+      - name: Commit Version Bump (Local for CI)
         run: |
           git config --local user.name "github-actions"
           git config --local user.email "github-actions@github.com"
-          git commit -am "chore: bump version to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
+          git commit -am "chore: bump version for CI to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
 
-      - name: Call Shared CI Workflow
-        uses: ./.github/workflows/ci-shared.yml
-        with:
-          job-name: "Build with versioning"
-          deploy: ${{ github.base_ref == 'main' }}
-
-      - name: Tag and Release (Only Main Branch)
-        if: github.base_ref == 'main'
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          git tag v$VERSION
-          git push origin v$VERSION
-          gh release create v$VERSION --title "Release $VERSION" --notes "Automated release from GitHub Actions"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-shared-ci-workflow:
+    needs: set-version
+    uses: ./.github/workflows/ci-shared.yml
+    with:
+      job-name: "Build with PR Versioning"
+      deploy: false # El despliegue real no ocurre en la validación de PR
+      target-branch: ${{ github.base_ref }}

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -10,6 +10,14 @@ on:
         required: false
         type: boolean
         default: false
+      target-branch:
+        required: false
+        type: string
+        default: ''
+
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   build:
@@ -22,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: ${vars.JDK_VERSION}
+          java-version: ${{ vars.JDK_VERSION }}
           server-id: github
           server-username: ${{ github.actor }}
           server-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-versioning.yml
+++ b/.github/workflows/ci-versioning.yml
@@ -1,0 +1,65 @@
+name: CI Versioning by Branch
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  set-version:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get branch name
+        id: branch
+        run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+
+      - name: Set version based on branch
+        id: version
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          case "$BRANCH" in
+            main)
+              echo "version=$(date +'%Y.%m.%d')" >> "$GITHUB_OUTPUT"
+              ;;
+            develop)
+              echo "version=0.0.1-SNAPSHOT" >> "$GITHUB_OUTPUT"
+              ;;
+            release/*)
+              echo "version=1.0.0-RC1" >> "$GITHUB_OUTPUT"
+              ;;
+            hotfix/*)
+              echo "version=1.0.1-${BRANCH##*/}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "version=0.0.1-unknown" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Update pom.xml Version
+        run: mvn org.codehaus.mojo:versions-maven-plugin:2.18.0:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Commit Version Bump
+        run: |
+          git config --local user.name "github-actions"
+          git config --local user.email "github-actions@github.com"
+          git commit -am "chore: bump version to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
+
+      - name: Call Shared CI Workflow
+        uses: ./.github/workflows/ci-shared.yml
+        with:
+          job-name: "Build with versioning"
+          deploy: ${{ github.base_ref == 'main' }}
+
+      - name: Tag and Release (Only Main Branch)
+        if: github.base_ref == 'main'
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          git tag v$VERSION
+          git push origin v$VERSION
+          gh release create v$VERSION --title "Release $VERSION" --notes "Automated release from GitHub Actions"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,71 @@
+name: Release Workflow
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-22.04
+    outputs:
+      final_version: ${{ steps.final_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Get branch name
+        id: branch_name
+        run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+      - name: Calculate final version for Release
+        id: final_version
+        run: |
+          BRANCH="${{ steps.branch_name.outputs.branch }}"
+          case "$BRANCH" in
+            main)
+              echo "version=$(date +'%Y.%m.%d')" >> "$GITHUB_OUTPUT"
+              ;;
+            release/*)
+              echo "version=${BRANCH#release/}-RC" >> "$GITHUB_OUTPUT"
+              ;;
+            hotfix/*)
+              echo "version=${BRANCH#hotfix/}-fix" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "version=unversioned" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "Final release version: ${{ steps.final_version.outputs.version }}"
+
+      - name: Tag and Release
+        if: startsWith(github.ref, 'refs/heads/main') # Solo para tags y releases en main
+        run: |
+          VERSION=${{ steps.final_version.outputs.version }}
+          echo "Creating tag v$VERSION"
+          git tag v$VERSION
+          git push origin v$VERSION
+
+          echo "Creating GitHub Release v$VERSION"
+          gh release create v$VERSION --title "Release $VERSION" --notes "Automated release from GitHub Actions for ${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-production:
+    needs: create-release
+    # Este job se ejecutará solo si el push fue a la rama 'main'
+    # y el job 'create-release' fue exitoso.
+    if: startsWith(github.ref, 'refs/heads/main') && success()
+    uses: ./.github/workflows/ci-shared.yml
+    with:
+      job-name: "Deploy to Production"
+      deploy: true # Activa el despliegue
+      target-branch: ${{ github.ref_name }} # Pasa el nombre de la rama (e.g., 'main')
+      # Puedes pasar la versión final si el workflow compartido la necesita
+      # calculated-version: ${{ needs.create-release.outputs.final_version }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Asegura que el token se pase si el shared workflow lo requiere

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.18.0</version>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This pull request introduces automated versioning based on branch naming conventions and integrates it into the CI workflow. It also adds the `versions-maven-plugin` to the `pom.xml` file to support version updates. Below are the key changes:

### CI Workflow Enhancements:
* Added a new GitHub Actions workflow (`.github/workflows/ci-versioning.yml`) to automate versioning based on branch names (`main`, `develop`, `release/**`, `hotfix/**`) and update the `pom.xml` file accordingly. The workflow also includes steps for tagging and releasing versions on the `main` branch.

### Maven Plugin Update:
* Added the `versions-maven-plugin` (version 2.18.0) to the `pom.xml` file to enable programmatic version updates during the CI process.