### PR TITLE
Add CI workflows for PR validation and release management

### DIFF
--- a/.github/workflows/ci-pr-validator.yml
+++ b/.github/workflows/ci-pr-validator.yml
@@ -1,0 +1,61 @@
+name: CI Pull Request Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  set-version:
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get branch name
+        id: branch
+        run: echo "branch=${GITHUB_HEAD_REF}" >> $GITHUB_OUTPUT
+
+      - name: Set version based on branch
+        id: version
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          case "$BRANCH" in
+            main)
+              echo "version=$(date +'%Y.%m.%d-PR')" >> "$GITHUB_OUTPUT"
+              ;;
+            develop)
+              echo "version=0.0.1-SNAPSHOT" >> "$GITHUB_OUTPUT"
+              ;;
+            release/*)
+              echo "version=1.0.0-RC1" >> "$GITHUB_OUTPUT"
+              ;;
+            hotfix/*)
+              echo "version=1.0.1-${BRANCH##*/}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "version=0.0.1-unknown-PR" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "Calculated PR version: ${{ steps.version.outputs.version }}"
+
+      - name: Update pom.xml Version (for CI testing)
+        run: mvn org.codehaus.mojo:versions-maven-plugin:2.18.0:set -DnewVersion=${{ steps.version.outputs.version }} -DgenerateBackupPoms=false
+
+      - name: Commit Version Bump (Local for CI)
+        run: |
+          git config --local user.name "github-actions"
+          git config --local user.email "github-actions@github.com"
+          git commit -am "chore: bump version for CI to ${{ steps.version.outputs.version }}" || echo "No changes to commit"
+
+  call-shared-ci-workflow:
+    needs: set-version
+    uses: ./.github/workflows/ci-shared.yml
+    with:
+      job-name: "Build with PR Versioning"
+      deploy: false # El despliegue real no ocurre en la validación de PR
+      target-branch: ${{ github.base_ref }}

--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -10,6 +10,14 @@ on:
         required: false
         type: boolean
         default: false
+      target-branch:
+        required: false
+        type: string
+        default: ''
+
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 jobs:
   build:
@@ -22,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: oracle
-          java-version: ${vars.JDK_VERSION}
+          java-version: ${{ vars.JDK_VERSION }}
           server-id: github
           server-username: ${{ github.actor }}
           server-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,67 @@
+name: Release Workflow
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-22.04
+    outputs:
+      final_version: ${{ steps.final_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Get branch name
+        id: branch_name
+        run: echo "branch=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+
+      - name: Calculate final version for Release
+        id: final_version
+        run: |
+          BRANCH="${{ steps.branch_name.outputs.branch }}"
+          case "$BRANCH" in
+            main)
+              echo "version=$(date +'%Y.%m.%d')" >> "$GITHUB_OUTPUT"
+              ;;
+            release/*)
+              echo "version=${BRANCH#release/}-RC" >> "$GITHUB_OUTPUT"
+              ;;
+            hotfix/*)
+              echo "version=${BRANCH#hotfix/}-fix" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "version=unversioned" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "Final release version: ${{ steps.final_version.outputs.version }}"
+
+      - name: Tag and Release
+        if: startsWith(github.ref, 'refs/heads/main')
+        run: |
+          VERSION=${{ steps.final_version.outputs.version }}
+          echo "Creating tag v$VERSION"
+          git tag v$VERSION
+          git push origin v$VERSION
+
+          echo "Creating GitHub Release v$VERSION"
+          gh release create v$VERSION --title "Release $VERSION" --notes "Automated release from GitHub Actions for ${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-production:
+    needs: create-release
+    if: startsWith(github.ref, 'refs/heads/main') && success()
+    uses: ./.github/workflows/ci-shared.yml
+    with:
+      job-name: "Deploy to Production"
+      deploy: true
+      target-branch: ${{ github.ref_name }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces new GitHub Actions workflows and updates existing ones to improve CI/CD processes, including pull request validation, release management, and shared workflow enhancements. The changes focus on automating version management, tagging releases, and enabling reusable workflows.

### New Workflows

* **Pull Request Validation Workflow**: Added a new `.github/workflows/ci-pr-validator.yml` workflow to validate pull requests by dynamically setting versions based on branch types (e.g., `main`, `develop`, `release/**`, `hotfix/**`) and updating the `pom.xml` version for CI testing. It also integrates with a shared CI workflow for further validation.

* **Release Workflow**: Introduced a `.github/workflows/release-workflow.yml` workflow to automate release tagging and deployment. It calculates final release versions based on branch names, creates GitHub tags and releases, and triggers a production deployment using the shared CI workflow.

### Updates to Shared Workflow

* **New Input Parameter**: Added a `target-branch` input parameter to `.github/workflows/ci-shared.yml` to support branch-specific operations.

* **Secrets Configuration**: Included the `GITHUB_TOKEN` secret as a required input in the shared workflow for authentication purposes.

* **Syntax Fix**: Corrected the syntax for referencing `vars.JDK_VERSION` in the shared workflow to use `${{ vars.JDK_VERSION }}` for consistency with GitHub Actions expressions.