### PR TITLE
Add HexColor validation annotation and validator implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/elara/app/validation_utils_test/annotation/HexColor.java
+++ b/src/main/java/com/elara/app/validation_utils_test/annotation/HexColor.java
@@ -4,11 +4,10 @@ import com.elara.app.validation_utils_test.validator.HexColorValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = HexColorValidator.class)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 public @interface HexColor {

--- a/src/main/java/com/elara/app/validation_utils_test/annotation/HexColor.java
+++ b/src/main/java/com/elara/app/validation_utils_test/annotation/HexColor.java
@@ -1,0 +1,22 @@
+package com.elara.app.validation_utils_test.annotation;
+
+import com.elara.app.validation_utils_test.validator.HexColorValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = HexColorValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface HexColor {
+
+    String message() default "Invalid hex color code";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/elara/app/validation_utils_test/validator/HexColorValidator.java
+++ b/src/main/java/com/elara/app/validation_utils_test/validator/HexColorValidator.java
@@ -4,13 +4,15 @@ import com.elara.app.validation_utils_test.annotation.HexColor;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
+import java.util.regex.Pattern;
+
 public class HexColorValidator implements ConstraintValidator<HexColor, String> {
 
-    private static final String HEX_COLOR_PATTERN = "^#([0-9a-fA-F]{6})$";
+    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("^#([0-9a-fA-F]{6})$");
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
         if (value == null || value.isEmpty()) return true;
-        return value.matches(HEX_COLOR_PATTERN);
+        return HEX_COLOR_PATTERN.matcher(value).matches();
     }
 }

--- a/src/main/java/com/elara/app/validation_utils_test/validator/HexColorValidator.java
+++ b/src/main/java/com/elara/app/validation_utils_test/validator/HexColorValidator.java
@@ -1,0 +1,16 @@
+package com.elara.app.validation_utils_test.validator;
+
+import com.elara.app.validation_utils_test.annotation.HexColor;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class HexColorValidator implements ConstraintValidator<HexColor, String> {
+
+    private static final String HEX_COLOR_PATTERN = "^#([0-9a-fA-F]{6})$";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null || value.isEmpty()) return true;
+        return value.matches(HEX_COLOR_PATTERN);
+    }
+}

--- a/src/test/java/com/elara/app/validation_utils_test/validator/HexColorValidatorTest.java
+++ b/src/test/java/com/elara/app/validation_utils_test/validator/HexColorValidatorTest.java
@@ -1,0 +1,87 @@
+package com.elara.app.validation_utils_test.validator;
+
+import com.elara.app.validation_utils_test.annotation.HexColor;
+import jakarta.validation.Payload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HexColorValidatorTest {
+
+    private HexColor createAnnotation() {
+        return new HexColor() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return null;
+            }
+
+            @Override
+            public String message() {
+                return "";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                return new Class[0];
+            }
+        };
+    }
+
+    @Nested
+    class ValidationTest {
+        HexColorValidator hexColorValidator = new HexColorValidator();
+
+        @BeforeEach
+        void init() {
+            hexColorValidator.initialize(createAnnotation());
+        }
+
+        @Test
+        void acceptsValidFullHexColor() {
+            assertTrue(hexColorValidator.isValid("#1A2B3C", null));
+        }
+
+        @Test
+        void acceptsNullValue() {
+            assertTrue(hexColorValidator.isValid(null, null));
+        }
+
+        @Test
+        void acceptsEmptyValue() {
+            assertTrue(hexColorValidator.isValid("", null));
+        }
+
+        @Test
+        void rejectsShorthandWithHash() {
+            assertFalse(hexColorValidator.isValid("#123", null));
+        }
+
+        @Test
+        void rejectsShorthandWithoutHash() {
+            assertFalse(hexColorValidator.isValid("123", null));
+        }
+
+        @Test
+        void rejectsWithoutHash() {
+            assertFalse(hexColorValidator.isValid("1A2B3C", null));
+        }
+
+        @Test
+        void rejectsInvalidCharacters() {
+            assertFalse(hexColorValidator.isValid("#ZZZZZZ", null));
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a custom validation annotation, `@HexColor`, for validating hexadecimal color codes. It includes the implementation of the annotation, its validator, and corresponding unit tests. Additionally, a new dependency for validation support has been added to the project.

### Validation Feature Implementation:
* **Added `@HexColor` annotation**: A custom validation annotation was created to validate hexadecimal color codes. It uses `HexColorValidator` as its validation logic. (`src/main/java/com/elara/app/validation_utils_test/annotation/HexColor.java`)
* **Implemented `HexColorValidator`**: This validator checks if a given string matches the pattern for a valid six-character hexadecimal color code (e.g., `#1A2B3C`). Null or empty values are considered valid. (`src/main/java/com/elara/app/validation_utils_test/validator/HexColorValidator.java`)

### Testing:
* **Added unit tests for `HexColorValidator`**: Comprehensive test cases were added to ensure the validator behaves as expected for valid, null, empty, and invalid inputs (e.g., missing `#`, shorthand hex, invalid characters). (`src/test/java/com/elara/app/validation_utils_test/validator/HexColorValidatorTest.java`)

### Dependency Management:
* **Added `spring-boot-starter-validation` dependency**: This dependency was added to the `pom.xml` file to support the Jakarta Bean Validation API used for the custom annotation. (`pom.xml`)