### PR TITLE
Remove GitHub token from release workflow secrets

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -63,5 +63,3 @@ jobs:
       job-name: "Deploy to Production"
       deploy: true
       target-branch: ${{ github.ref_name }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-workflow.yml` file. The change removes the `secrets` section, specifically the `GITHUB_TOKEN`, from the "Deploy to Production" job configuration.