### PR TITLE
Hotfix/remove GitHub token from workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -63,5 +63,3 @@ jobs:
       job-name: "Deploy to Production"
       deploy: true
       target-branch: ${{ github.ref_name }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request modifies the `.github/workflows/release-workflow.yml` file to remove the `secrets` configuration from the "Deploy to Production" job, simplifying the workflow configuration.

* [`.github/workflows/release-workflow.yml`](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014L66-L67): Removed the `secrets` block, including `GITHUB_TOKEN`, from the "Deploy to Production" job configuration.