### PR TITLE
Add write permissions for contents in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     outputs:
       final_version: ${{ steps.final_version.outputs.version }}
     steps:
@@ -63,5 +65,3 @@ jobs:
       job-name: "Deploy to Production"
       deploy: true
       target-branch: ${{ github.ref_name }}
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure the necessary permissions are set for the `create-release` job.

Workflow configuration changes:

* [`.github/workflows/release-workflow.yml`](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014R13-R14): Added `permissions` with `contents: write` to the `create-release` job to grant write access to repository contents during the workflow execution.