### PR TITLE
Add write permissions for packages in release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      packages: write
     outputs:
       final_version: ${{ steps.final_version.outputs.version }}
     steps:


### PR DESCRIPTION
This pull request updates the permissions in the release workflow file to include write access for packages.

* [`.github/workflows/release-workflow.yml`](diffhunk://#diff-35fb489f38dbca17d499e36a6a81fec543d4debd63c8ea3e6f0920180cc38014R15): Added `packages: write` to the `permissions` section under `jobs`, enabling the workflow to manage package-related operations.