### PR TITLE
Hotfix/give package permissions to workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      packages: write
     outputs:
       final_version: ${{ steps.final_version.outputs.version }}
     steps:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-workflow.yml` file. The change adds `packages: write` to the `permissions` section of the `jobs:` configuration to allow write access to packages.