### PR TITLE
Change groupId to com.github.elara-app in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<version>3.5.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.elara.app</groupId>
+	<groupId>com.github.elara-app</groupId>
 	<artifactId>validation-utils-test</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>validation-utils-test</name>


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file. The change updates the `groupId` to reflect a new namespace.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L11-R11): Changed the `groupId` from `com.elara.app` to `com.github.elara-app` to align with the updated project namespace.