### PR TITLE
Add step to display Maven settings.xml for debugging

### DIFF
--- a/.github/workflows/ci-shared.yml
+++ b/.github/workflows/ci-shared.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build and Verify
         run: mvn clean verify --batch-mode
 
+      - name: Show Maven Settings.xml for Debugging
+        run: cat ~/.m2/settings.xml
+
       - name: Deploy to Maven (if enabled)
         if: ${{ inputs.deploy == true }}
         run: mvn deploy -DskipTests


### PR DESCRIPTION
This pull request introduces a debugging step to the CI workflow by adding a command to display the Maven `settings.xml` file. This helps in diagnosing issues related to Maven configuration during the build process.

* [`.github/workflows/ci-shared.yml`](diffhunk://#diff-20aca357e16bcaabb2fe949dae964eca93531393ce8ff82d372a8b3ca4a409beR46-R48): Added a new step, "Show Maven Settings.xml for Debugging," to output the contents of the Maven `settings.xml` file for troubleshooting purposes.